### PR TITLE
Frontend token

### DIFF
--- a/src/components/FormCreate.tsx
+++ b/src/components/FormCreate.tsx
@@ -4,6 +4,7 @@ import { FormEvent, useState } from "react";
 // Project files
 import ListInput from "components/ListInput";
 import { useModal } from "state/ModalContext";
+import { useUser } from "state/UserContext";
 import fakeFetch from "scripts/fakeFetch";
 
 interface iProps {
@@ -14,13 +15,17 @@ interface iProps {
 export default function FormCreate({ endPoint, fields }: iProps) {
   // Global state
   const { setModal } = useModal();
+  const { token } = useUser();
 
   // Local state
   const [form, setForm] = useState({});
 
   //Properties
-  const METHOD = "POST"
-  const HEADERS = { "Content-type": "application/json; charset=UTF-8"};
+  const METHOD = "POST";
+  const HEADERS = {
+    "Content-type": "application/json; charset=UTF-8",
+    auth: token,
+  };
 
   // Methods
 
@@ -29,13 +34,13 @@ export default function FormCreate({ endPoint, fields }: iProps) {
     fetch(endPoint + "create", {
       method: METHOD,
       headers: HEADERS,
-      body: JSON.stringify(form),})
+      body: JSON.stringify(form),
+    })
       .then(onSuccess)
       .catch((error) => onFailure(error));
-      console.log(endPoint);
-      console.log(form);
+    console.log(endPoint);
+    console.log(form);
   }
-
 
   function onSuccess() {
     alert("Item created!");

--- a/src/components/FormCreate.tsx
+++ b/src/components/FormCreate.tsx
@@ -18,13 +18,24 @@ export default function FormCreate({ endPoint, fields }: iProps) {
   // Local state
   const [form, setForm] = useState({});
 
+  //Properties
+  const METHOD = "POST"
+  const HEADERS = { "Content-type": "application/json; charset=UTF-8"};
+
   // Methods
+
   async function onSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    fakeFetch(endPoint + "create/", form)
+    fetch(endPoint + "create", {
+      method: METHOD,
+      headers: HEADERS,
+      body: JSON.stringify(form),})
       .then(onSuccess)
       .catch((error) => onFailure(error));
+      console.log(endPoint);
+      console.log(form);
   }
+
 
   function onSuccess() {
     alert("Item created!");

--- a/src/components/FormCreate.tsx
+++ b/src/components/FormCreate.tsx
@@ -5,7 +5,6 @@ import { FormEvent, useState } from "react";
 import ListInput from "components/ListInput";
 import { useModal } from "state/ModalContext";
 import { useUser } from "state/UserContext";
-import fakeFetch from "scripts/fakeFetch";
 
 interface iProps {
   endPoint: string;
@@ -24,18 +23,20 @@ export default function FormCreate({ endPoint, fields }: iProps) {
   const METHOD = "POST";
   const HEADERS = {
     "Content-type": "application/json; charset=UTF-8",
-    auth: token,
+    Authorization: "Bearer " + token,
   };
 
   // Methods
 
   async function onSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
+    
     fetch(endPoint + "create", {
       method: METHOD,
       headers: HEADERS,
       body: JSON.stringify(form),
     })
+      .then((response) => response.json())
       .then(onSuccess)
       .catch((error) => onFailure(error));
     console.log(endPoint);

--- a/src/components/FormDelete.tsx
+++ b/src/components/FormDelete.tsx
@@ -14,13 +14,34 @@ export default function FormDelete({ endPoint, id }: iProps) {
   // Global state
   const { setModal } = useModal();
 
+    //Properties
+    const METHOD = "DELETE"
+    const HEADERS = { "Content-type": "application/json; charset=UTF-8"};
+
   // Methods
   async function onSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    fakeFetch(endPoint + "delete/", id)
+    fetch(endPoint + "delete/"+id,{
+      method: METHOD,
+      headers: HEADERS})
       .then(onSuccess)
       .catch((error) => onFailure(error));
+      console.log(endPoint);
+      console.log(id);
   }
+
+  /*
+ fetch(endPoint + "movies/create", {
+      method: METHOD,
+      headers: HEADERS,
+      body: JSON.stringify(form),})
+      .then(onSuccess)
+      .catch((error) => onFailure(error));
+      console.log(endPoint);
+      console.log(form);
+  }
+
+  */
 
   function onSuccess() {
     alert("Item deleted!");

--- a/src/components/FormDelete.tsx
+++ b/src/components/FormDelete.tsx
@@ -1,9 +1,10 @@
 // MPM packages
-import { FormEvent } from "react";
+import { FormEvent, useState } from "react";
 
 // Project files
+import ListInput from "components/ListInput";
 import { useModal } from "state/ModalContext";
-import fakeFetch from "scripts/fakeFetch";
+import { useUser } from "state/UserContext";
 
 interface iProps {
   endPoint: string;
@@ -13,10 +14,19 @@ interface iProps {
 export default function FormDelete({ endPoint, id }: iProps) {
   // Global state
   const { setModal } = useModal();
+  const { token } = useUser();
+  const { setToken, setUser } = useUser();
+
+    // Local state
+    const [form, setForm] = useState({});
 
     //Properties
-    const METHOD = "DELETE"
-    const HEADERS = { "Content-type": "application/json; charset=UTF-8"};
+  //Properties
+  const METHOD = "DELETE";
+  const HEADERS = {
+    "Content-type": "application/json; charset=UTF-8",
+    Authorization: "Bearer " + token,
+  };
 
   // Methods
   async function onSubmit(event: FormEvent<HTMLFormElement>) {
@@ -30,18 +40,6 @@ export default function FormDelete({ endPoint, id }: iProps) {
       console.log(id);
   }
 
-  /*
- fetch(endPoint + "movies/create", {
-      method: METHOD,
-      headers: HEADERS,
-      body: JSON.stringify(form),})
-      .then(onSuccess)
-      .catch((error) => onFailure(error));
-      console.log(endPoint);
-      console.log(form);
-  }
-
-  */
 
   function onSuccess() {
     alert("Item deleted!");

--- a/src/components/FormUpdate.tsx
+++ b/src/components/FormUpdate.tsx
@@ -20,15 +20,36 @@ export default function FormUpdate({ endPoint, fields, data }: iProps) {
   // Local state
   const [form, setForm] = useState(generateFields(fields, data));
 
+
+  //Properties
+  const METHOD = "PUT"
+  const HEADERS = { "Content-type": "application/json; charset=UTF-8"};
+
   // Methods
   async function onSubmit(event: FormEvent<HTMLFormElement>) {
     const editedItem = { ...form, id: data.id };
+    
 
-    event.preventDefault();
-    fakeFetch(endPoint + "update/", editedItem)
+    /*event.preventDefault();
+    fetch(endPoint + "update/", editedItem)
       .then(onSuccess)
       .catch((error) => onFailure(error));
-  }
+      console.log(editedItem);
+      console.log(endPoint);
+  }*/
+
+  event.preventDefault();
+  fetch(endPoint + "update", {
+    method: METHOD,
+    headers: HEADERS,
+    body: JSON.stringify(editedItem),
+   })
+   .then(onSuccess)
+   .catch((error)=>onFailure(error));
+   console.log(editedItem);
+   console.log(endPoint);
+}
+
 
   function onSuccess() {
     alert("Item edited!");

--- a/src/components/FormUpdate.tsx
+++ b/src/components/FormUpdate.tsx
@@ -5,7 +5,7 @@ import { FormEvent, useState } from "react";
 import ListInput from "components/ListInput";
 import { generateFields } from "scripts/formUtilities";
 import { useModal } from "state/ModalContext";
-import fakeFetch from "scripts/fakeFetch";
+import { useUser } from "state/UserContext";
 
 interface iProps {
   endPoint: string;
@@ -16,27 +16,23 @@ interface iProps {
 export default function FormUpdate({ endPoint, fields, data }: iProps) {
   // Global state
   const { setModal } = useModal();
+  const { token } = useUser();
 
   // Local state
   const [form, setForm] = useState(generateFields(fields, data));
 
 
   //Properties
-  const METHOD = "PUT"
-  const HEADERS = { "Content-type": "application/json; charset=UTF-8"};
+  const METHOD = "PUT";
+  const HEADERS = {
+    "Content-type": "application/json; charset=UTF-8",
+    Authorization: "Bearer " + token,
+  };
 
   // Methods
   async function onSubmit(event: FormEvent<HTMLFormElement>) {
     const editedItem = { ...form, id: data.id };
     
-
-    /*event.preventDefault();
-    fetch(endPoint + "update/", editedItem)
-      .then(onSuccess)
-      .catch((error) => onFailure(error));
-      console.log(editedItem);
-      console.log(endPoint);
-  }*/
 
   event.preventDefault();
   fetch(endPoint + "update", {
@@ -48,6 +44,7 @@ export default function FormUpdate({ endPoint, fields, data }: iProps) {
    .catch((error)=>onFailure(error));
    console.log(editedItem);
    console.log(endPoint);
+   console.log(token);
 }
 
 

--- a/src/pages/AdminMedia.tsx
+++ b/src/pages/AdminMedia.tsx
@@ -29,18 +29,24 @@ export default function AdminMedia() {
   const [data, setData] = useState(new Array<iMedia>());
 
   // Properties
-  const endPoint: string = "media/";
+  //const endPoint: string = "media/";
+
+  const endPoint = "http://localhost:9090/api/";
   const fields = chooseFields(code);
 
   // Methods
   useEffect(() => {
-    fakeFetch(endPoint + code + "/")
-      .then((response) => onSuccess(response.data))
+    fetch(endPoint+code+"/")
+      .then ((response) => response.json())
+      .then((result) => onSuccess(result))
       .catch((error) => onFailure(error));
+      console.log(data);
   }, [code]);
+
 
   function onSuccess(data: iMedia[]) {
     setData(data);
+    console.log(data);
     setStatus(eStatus.READY);
   }
 
@@ -63,9 +69,9 @@ export default function AdminMedia() {
   }
 
   // Components
-  const Create = <FormCreate fields={fields} endPoint={endPoint} />;
+  const Create = <FormCreate fields={fields} endPoint={endPoint+code+"/"} />;
   const Items = data.map((item) => (
-    <Item key={item.id} item={item} endPoint={endPoint} fields={fields} />
+    <Item key={item.id} item={item} endPoint={endPoint+code+"/"} fields={fields} />
   ));
 
   // Safeguards

--- a/src/pages/AdminMedia.tsx
+++ b/src/pages/AdminMedia.tsx
@@ -1,5 +1,6 @@
 // Fake data (replace this with a real fetch)
-import fakeFetch from "scripts/fakeFetch";
+//import fakeFetch from "scripts/fakeFetch";
+import { useUser } from "state/UserContext";
 
 // Node modules
 import { useEffect, useState } from "react";
@@ -24,6 +25,8 @@ export default function AdminMedia() {
   const { code } = useParams();
   const { setModal } = useModal();
 
+  const { token } = useUser();
+
   // Local state
   const [status, setStatus] = useState(eStatus.LOADING);
   const [data, setData] = useState(new Array<iMedia>());
@@ -31,16 +34,26 @@ export default function AdminMedia() {
   // Properties
   //const endPoint: string = "media/";
 
-  const endPoint = "http://localhost:9090/api/";
+  const endPoint = "http://localhost:9090/api/v1/";
   const fields = chooseFields(code);
+
+     const METHOD = "GET";
+     const HEADERS = {
+       "Content-type": "application/json; charset=UTF-8",
+       Authorization: "Bearer " + token,
+    
+     };
 
   // Methods
   useEffect(() => {
-    fetch(endPoint+code+"/")
+    fetch(endPoint+code+"/",{
+      method: METHOD,
+      headers: HEADERS,})
       .then ((response) => response.json())
       .then((result) => onSuccess(result))
       .catch((error) => onFailure(error));
       console.log(data);
+      console.log(endPoint+code);
   }, [code]);
 
 

--- a/src/pages/AdminTVSeries.tsx
+++ b/src/pages/AdminTVSeries.tsx
@@ -27,14 +27,19 @@ export default function AdminDetailSeries() {
   const [data, setData] = useState(new Array<iTVSeries>());
 
   // Properties
-  const endPoint: string = "tv-series/:id/";
+  //const endPoint: string = "tv-series/:id/";
 
-  // Methods
-  useEffect(() => {
-    fakeFetch(endPoint, code)
-      .then((response) => onSuccess(response.data))
-      .catch((error) => onFailure(error));
-  }, []);
+  const endPoint = "http://localhost:9090/api/episodes/";
+
+  
+ // Methods
+ useEffect(() => {
+  fetch(endPoint+code)
+    .then ((response) => response.json())
+    .then((result) => onSuccess(result))
+    .catch((error) => onFailure(error));
+    console.log(data);
+}, [code]);
 
   function onSuccess(data: iTVSeries[]) {
     setData(data);
@@ -49,7 +54,7 @@ export default function AdminDetailSeries() {
   // Components
   const Create = <FormCreate fields={fields} endPoint={endPoint} />;
   const Items = data.map((item) => (
-    <Item key={item.id} item={item} endPoint={endPoint} fields={fields} />
+    <Item key={item.id} item={item} endPoint={endPoint+code+"/"} fields={fields} />
   ));
 
   // Safeguards

--- a/src/pages/AdminTVSeries.tsx
+++ b/src/pages/AdminTVSeries.tsx
@@ -29,7 +29,7 @@ export default function AdminDetailSeries() {
   // Properties
   //const endPoint: string = "tv-series/:id/";
 
-  const endPoint = "http://localhost:9090/api/episodes/";
+  const endPoint = "http://localhost:9090/api/v1/episodes/";
 
   
  // Methods

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -20,7 +20,7 @@ export default function Home() {
   const [data, setData] = useState(new Array<iMedia>());
 
   // Properties
-  const endPoint = "media/";
+  const endPoint = "http://localhost:9090/api/media/";
   const tvSeries = data.filter((item) => item.media_type_id === 1);
   const movies = data.filter((item) => item.media_type_id === 2);
   const documentaries = data.filter((item) => item.media_type_id === 3);
@@ -28,8 +28,9 @@ export default function Home() {
 
   // Methods
   useEffect(() => {
-    fakeFetch(endPoint)
-      .then((response) => onSuccess(response.data))
+    fetch(endPoint)
+      .then ((response) => response.json())
+      .then((result) => onSuccess(result))
       .catch((error) => onFailure(error));
   }, []);
 

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,8 +1,10 @@
 // Fake data (replace this with a real fetch)
-import fakeFetch from "scripts/fakeFetch";
+//import fakeFetch from "scripts/fakeFetch";
+import { useUser } from "state/UserContext";
 
 // Node modules
 import { useEffect, useState } from "react";
+
 
 // Project files
 import HeroHome from "components/HeroHome";
@@ -19,19 +21,34 @@ export default function Home() {
   const [status, setStatus] = useState(eStatus.LOADING);
   const [data, setData] = useState(new Array<iMedia>());
 
+
+  const { token } = useUser();
+
   // Properties
-  const endPoint = "http://localhost:9090/api/media/";
+  const endPoint = "http://localhost:9090/api/v1/media/";
   const tvSeries = data.filter((item) => item.media_type_id === 1);
   const movies = data.filter((item) => item.media_type_id === 2);
   const documentaries = data.filter((item) => item.media_type_id === 3);
   const firstItemToShow = tvSeries[0];
 
+   //Properties
+   const METHOD = "GET";
+   const HEADERS = {
+     "Content-type": "application/json; charset=UTF-8",
+     Authorization: "Bearer " + token,
+  
+   };
+
   // Methods
   useEffect(() => {
-    fetch(endPoint)
+
+    fetch(endPoint,{
+      method: METHOD,
+      headers: HEADERS,})
       .then ((response) => response.json())
       .then((result) => onSuccess(result))
       .catch((error) => onFailure(error));
+      console.log(HEADERS);
   }, []);
 
   function onSuccess(data: iMedia[]) {

--- a/src/pages/Media.tsx
+++ b/src/pages/Media.tsx
@@ -24,14 +24,16 @@ export default function Media() {
   const [data, setData] = useState(new Array<iMedia>());
 
   // Properties
-  const endPoint = "media/";
+  const endPoint = "http://localhost:9090/api/";
 
   // Methods
   useEffect(() => {
-    fakeFetch(endPoint + code + "/")
-      .then((response) => onSuccess(response.data))
-      .catch((error) => onFailure(error));
+    fetch(endPoint + code + "/")
+    .then ((response) => response.json())
+    .then((result) => onSuccess(result))
+    .catch((error) => onFailure(error));
   }, [code]);
+
 
   function onSuccess(data: iMedia[]) {
     setData(data);

--- a/src/pages/Media.tsx
+++ b/src/pages/Media.tsx
@@ -1,5 +1,6 @@
 // Fake data (replace this with a real fetch)
-import fakeFetch from "scripts/fakeFetch";
+//import fakeFetch from "scripts/fakeFetch";
+import { useUser } from "state/UserContext";
 
 // Node modules
 import { useParams } from "react-router-dom";
@@ -19,16 +20,29 @@ export default function Media() {
   // Global state
   const { code } = useParams();
 
+  const { token } = useUser();
+
   // Local state
   const [status, setStatus] = useState(eStatus.LOADING);
   const [data, setData] = useState(new Array<iMedia>());
 
   // Properties
-  const endPoint = "http://localhost:9090/api/";
+  const endPoint = "http://localhost:9090/api/v1/media/";
+
+
+   //Properties
+   const METHOD = "GET";
+   const HEADERS = {
+     "Content-type": "application/json; charset=UTF-8",
+     Authorization: "Bearer " + token,
+  
+   };
 
   // Methods
   useEffect(() => {
-    fetch(endPoint + code + "/")
+    fetch(endPoint + code + "/", {
+      method: METHOD,
+      headers: HEADERS,})
     .then ((response) => response.json())
     .then((result) => onSuccess(result))
     .catch((error) => onFailure(error));

--- a/src/pages/SignIn.tsx
+++ b/src/pages/SignIn.tsx
@@ -9,11 +9,10 @@ import { Link } from "react-router-dom";
 import ListInput from "components/ListInput";
 import Fields from "data/fields-sign-in.json";
 import { useUser } from "state/UserContext";
-import iUser from "types/iUser";
 
 export default function Login() {
   // Global state
-  const { user, setUser } = useUser();
+  const { setToken, setUser } = useUser();
 
   // Local state
   const [form, setForm] = useState({ email: "", password: "" });
@@ -26,13 +25,16 @@ export default function Login() {
     event.preventDefault();
 
     fakeFetch(endPoint, form)
-      .then((response) => onSuccess(response.data))
+      .then((response) => response.json())
+      .then((result) => onSuccess(result))
       .catch((error) => onFailure(error));
   }
 
-  function onSuccess(returningUser: iUser) {
-    console.log(returningUser);
-    setUser(returningUser);
+  function onSuccess(result: any) {
+    console.log("onSuccess result", result);
+
+    setToken(result.token);
+    setUser(result.user);
   }
 
   function onFailure(error: string) {

--- a/src/pages/SignIn.tsx
+++ b/src/pages/SignIn.tsx
@@ -1,5 +1,5 @@
 // Fake fetch
-import fakeFetch from "scripts/fakeFetch";
+//import fakeFetch from "scripts/fakeFetch";
 
 // Node modules
 import { FormEvent, useState } from "react";
@@ -18,13 +18,25 @@ export default function Login() {
   const [form, setForm] = useState({ email: "", password: "" });
 
   // Properties
-  const endPoint = "login/";
+  const endPoint = "http://localhost:9090/api/v1/auth/login";
 
   // Methods
   function onSubmit(event: FormEvent): void {
     event.preventDefault();
 
-    fakeFetch(endPoint, form)
+    const setup = {
+      method: "POST",
+      mode: "cors",
+      cache: "no-cache",
+      credentials: "same-origin",
+      headers: { "Content-Type": "application/json" },
+      redirect: "follow", 
+      referrerPolicy: "no-referrer",
+      body: JSON.stringify(form),
+    };
+
+    // @ts-ignore
+    fetch(endPoint, setup)
       .then((response) => response.json())
       .then((result) => onSuccess(result))
       .catch((error) => onFailure(error));
@@ -32,9 +44,9 @@ export default function Login() {
 
   function onSuccess(result: any) {
     console.log("onSuccess result", result);
-
     setToken(result.token);
     setUser(result.user);
+    console.log(result.user);
   }
 
   function onFailure(error: string) {

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -14,7 +14,7 @@ import iUser from "types/iUser";
 export default function Login() {
   // Global state
   const navigate = useNavigate();
-  const { user, setUser } = useUser();
+  const { setToken, setUser } = useUser();
 
   // Local state
   const [form, setForm] = useState({});
@@ -27,15 +27,17 @@ export default function Login() {
     event.preventDefault();
 
     fakeFetch(endPoint, form)
-      .then((response) => onSuccess(response.data))
+      .then((response) => response.json())
+      .then((result) => onSuccess(result))
       .catch((error) => onFailure(error));
   }
 
-  function onSuccess(newUser: iUser) {
-    console.log(newUser);
+  function onSuccess(result: any) {
+    console.log("onSuccess result", result);
 
     alert("Welcome to Natflix!");
-    setUser(newUser);
+    setToken(result.token);
+    setUser(result.user);
     navigate("/");
   }
 

--- a/src/pages/SignUp.tsx
+++ b/src/pages/SignUp.tsx
@@ -20,26 +20,40 @@ export default function Login() {
   const [form, setForm] = useState({});
 
   // Properties
-  const endPoint = "register/";
+  const endPoint = "http://localhost:9090/api/v1/auth/register";
+  const METHOD = "POST"
+  const HEADERS = { "Content-type": "application/json; charset=UTF-8"};
 
   // Methods
   function onSubmit(event: FormEvent): void {
     event.preventDefault();
 
-    fakeFetch(endPoint, form)
+    fetch(endPoint, {
+      method: METHOD,
+      headers: HEADERS,
+      body: JSON.stringify(form),})
       .then((response) => response.json())
-      .then((result) => onSuccess(result))
+      .then(onSuccess)
       .catch((error) => onFailure(error));
   }
 
+  function onSuccess(result: any) {
+    console.log("onSuccess result", result);
+    setToken(result.token);
+    setUser(result.user);
+    console.log(result.user);
+    alert("Registration Successfull. Welcome to Natflix!");
+    navigate("/");
+  }
+  /*
   function onSuccess(result: any) {
     console.log("onSuccess result", result);
 
     alert("Welcome to Natflix!");
     setToken(result.token);
     setUser(result.user);
-    navigate("/");
-  }
+    navigate("/home");
+  }*/
 
   function onFailure(error: string) {
     console.error(Error);

--- a/src/scripts/fake-data/media.json
+++ b/src/scripts/fake-data/media.json
@@ -1,7 +1,7 @@
 [
   {
     "id": 1,
-    "title": "Seinfield",
+    "title": "Seinfieldssss",
     "media_type_id": 1,
     "genre_id": 3,
     "summary": "The show about nothing is a sitcom landmark, with comic Jerry and his three sardonic friends finding laughs in both the mundane and the ridiculous",
@@ -137,7 +137,7 @@
   },
   {
     "id": 16,
-    "title": "Servant of the people",
+    "title": "Servant of the peoplesssss",
     "media_type_id": 2,
     "genre_id": 2,
     "summary": "A political satire comedy about a high-school history teacher in his thirties who is unexpectedly elected President after a viral video filmed by one of his students shows him making a profane rant against government corruption.",

--- a/src/scripts/fakeFetch.ts
+++ b/src/scripts/fakeFetch.ts
@@ -7,6 +7,7 @@
 import fakeServer from "scripts/fakeServer";
 
 interface iResponse {
+  [x: string]: any;
   status: string;
   data: Array<any> | any;
 }

--- a/src/state/UserContext.tsx
+++ b/src/state/UserContext.tsx
@@ -10,13 +10,17 @@ interface iProps {
 }
 interface iValues {
   user: iUser | null;
+  token: string;
   setUser: Function;
+  setToken: Function;
 }
 
 // Properties
 const initialValues: iValues = {
   user: null,
+  token: "",
   setUser: () => {},
+  setToken: () => {},
 };
 const Context = createContext(initialValues);
 
@@ -24,9 +28,10 @@ const Context = createContext(initialValues);
 export function UserProvider({ children }: iProps) {
   // Local state
   const [user, setUser] = useState(null);
+  const [token, setToken] = useState("");
 
   // Properties
-  const value: iValues = { user, setUser };
+  const value: iValues = { user, token, setUser, setToken };
 
   return <Context.Provider value={value}>{children}</Context.Provider>;
 }


### PR DESCRIPTION
I have added the React state `token` and `setToken` to the `state/UserContext.jsx` file. With that, the SignIn page and SignUp page can receive an auth token from the backend and store it globally using the `setToken(result.token)` method.

This change assumes that the result from the server has the following format:
```
// Server result
{
  token: "string_of_100_of_characters,
  user: {
    id: 1,
   email: "eduardo@email.com"
   pass: "hashed_password_u_will_lose_points_for_non_encripted_passwords",
   role: "admin"
  }
}
```

Now to sent the token back to the backend to authorize a POST request, sent the token by using the following:
1. Start by using `import { useUser } from "state/UserContext";` to have access to the token.
2. Make the value of token available by using `const { token } = useUser();`
3. In the header put something like `const HEADERS = {auth: token }